### PR TITLE
Added functionality for keys in the config json, updated bids compatible run id, updated Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# dcm2bids
+tests/data/*
+!tests/data/config_test.json
+!tests/data/config_test_not_case_sensitive_option.json
+!tests/data/sidecars/*
+
+# dcm2bids documentation
+/site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Ubuntu 20.04 LTS
-FROM ubuntu:latest
+FROM ubuntu:xenial-20210722
 
 # Prepare environment
 RUN apt-get update && \
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 WORKDIR /src/dcm2niix_build
 
-RUN curl -sSLO https://github.com/rordenlab/dcm2niix/releases/latest/download/dcm2niix_lnx.zip && \
+RUN curl -sSLO https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20211006/dcm2niix_lnx.zip && \
     unzip dcm2niix_lnx.zip && \
     rm dcm2niix_lnx.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Use Ubuntu 20.04 LTS
+FROM ubuntu:latest
+
+# Prepare environment
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+                    ca-certificates \
+                    curl \
+                    unzip \
+                    git
+
+WORKDIR /src/dcm2niix_build
+
+RUN curl -sSLO https://github.com/rordenlab/dcm2niix/releases/latest/download/dcm2niix_lnx.zip && \
+    unzip dcm2niix_lnx.zip && \
+    rm dcm2niix_lnx.zip
+
+ENV PATH="/src/dcm2niix_build/:$PATH"
+
+WORKDIR /
+
+# Installing and setting up miniconda
+RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh && \
+    bash Miniconda3-py38_4.9.2-Linux-x86_64.sh -b -p /usr/local/miniconda && \
+    rm Miniconda3-py38_4.9.2-Linux-x86_64.sh
+
+# Set CPATH for packages relying on compiled libs (e.g. indexed_gzip)
+ENV PATH="/usr/local/miniconda/bin:$PATH" \
+    CPATH="/usr/local/miniconda/include:$CPATH" \
+    LANG="C.UTF-8" \
+    LC_ALL="C.UTF-8" \
+    PYTHONNOUSERSITE=1
+
+ADD . /src/Dcm2Bids
+
+WORKDIR /src/Dcm2Bids
+
+RUN python setup.py install
+
+WORKDIR /
+
+ENTRYPOINT ["dcm2bids"]

--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -54,6 +54,9 @@ class Dcm2bids(object):
         self.forceDcm2niix = forceDcm2niix
         self.logLevel = log_level
 
+        # Description map setup
+        self.set_descriptionMap()
+
         # logging setup
         self.set_logger()
 
@@ -66,6 +69,23 @@ class Dcm2bids(object):
         self.logger.info("session: %s", self.participant.session)
         self.logger.info("config: %s", os.path.realpath(config))
         self.logger.info("BIDS directory: %s", os.path.realpath(output_dir))
+
+    def set_descriptionMap(self):
+        """ Set a dictionary from keys to descriptions"""
+        self.descriptionMap = dict()
+        # Get all the file descriptions in json
+        descriptions = self.config["descriptions"]
+        for desc in descriptions:
+            key = desc.get('key')
+            # If the key is already in the description map
+            if (key in self.descriptionMap):
+                # Raise an error
+                # self.logger.error("Duplicate key error, key " + key + " found more than once")
+                pass
+            # Otherwise
+            else:
+                # Set the key to the given description
+                self.descriptionMap[key] = desc
 
     @property
     def dicomDirs(self):
@@ -181,7 +201,7 @@ class Dcm2bids(object):
 
             # use
             elif ext == ".json":
-                data = acquisition.dstSidecarData(self.config["descriptions"])
+                data = acquisition.dstSidecarData(self.config["descriptions"], self.descriptionMap)
                 save_json(dstFile, data)
                 os.remove(srcFile)
 

--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -227,18 +227,18 @@ class Acquisition(object):
         # Check if intendedFor is None
         if self.intendedFor != [None]:
             intendedValue = []
-            for index in self.intendedFor:
+            for intendedForRef in self.intendedFor:
                 intendedDesc = None
 
                 # If the intendedfor is an index
-                if isinstance(index, int):
+                if isinstance(intendedForRef, int):
                     # Grab that descriptions index
-                    intendedDesc = descriptions[index]
+                    intendedDesc = descriptions[intendedForRef]
                 # If the intendedfor is a string
-                elif isinstance(index, str):
+                elif isinstance(intendedForRef, str):
                     # Match the key
                     # for desc in descriptionMap:
-                    descMatch = descriptionMap.get(index)
+                    descMatch = descriptionMap.get(intendedForRef)
                     # If the description is matched in the descriptionMap
                     if (descMatch):
                         # Grab the matched description
@@ -246,7 +246,7 @@ class Acquisition(object):
                     # If the description is not matched in the descriptionMap
                     else:
                         # Throw an error saying that the key was not found
-                        print("Key not found error, description key " + index + " does not exist")
+                        print("Key not found error, description key " + intendedForRef + " does not exist")
 
                 if (intendedDesc):
                     session = self.participant.session

--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -217,27 +217,47 @@ class Acquisition(object):
         else:
             self._intendedFor = [value]
 
-    def dstSidecarData(self, descriptions):
+    def dstSidecarData(self, descriptions, descriptionMap):
         """
         """
         data = self.srcSidecar.origData
         data["Dcm2bidsVersion"] = __version__
 
         # intendedFor key
+        # Check if intendedFor is None
         if self.intendedFor != [None]:
             intendedValue = []
             for index in self.intendedFor:
-                intendedDesc = descriptions[index]
+                intendedDesc = None
 
-                session = self.participant.session
-                dataType = intendedDesc["dataType"]
+                # If the intendedfor is an index
+                if isinstance(index, int):
+                    # Grab that descriptions index
+                    intendedDesc = descriptions[index]
+                # If the intendedfor is a string
+                elif isinstance(index, str):
+                    # Match the key
+                    # for desc in descriptionMap:
+                    descMatch = descriptionMap.get(index)
+                    # If the description is matched in the descriptionMap
+                    if (descMatch):
+                        # Grab the matched description
+                        intendedDesc = descMatch
+                    # If the description is not matched in the descriptionMap
+                    else:
+                        # Throw an error saying that the key was not found
+                        print("Key not found error, description key " + index + " does not exist")
 
-                niiFile = self.participant.prefix
-                niiFile += self.prepend(intendedDesc.get("customLabels", ""))
-                niiFile += self.prepend(intendedDesc["modalityLabel"])
-                niiFile += ".nii.gz"
+                if (intendedDesc):
+                    session = self.participant.session
+                    dataType = intendedDesc["dataType"]
 
-                intendedValue.append(opj(session, dataType, niiFile).replace("\\", "/"))
+                    niiFile = self.participant.prefix
+                    niiFile += self.prepend(intendedDesc.get("customLabels", ""))
+                    niiFile += self.prepend(intendedDesc["modalityLabel"])
+                    niiFile += ".nii.gz"
+
+                    intendedValue.append(opj(session, dataType, niiFile).replace("\\", "/"))
 
             if len(intendedValue) == 1:
                 data["IntendedFor"] = intendedValue[0]

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -34,7 +34,7 @@ class DEFAULT(object):
     compKeys = ["SeriesNumber", "AcquisitionTime", "SidecarFilename"]
     searchMethod = "fnmatch"
     searchMethodChoices = ["fnmatch", "re"]
-    runTpl = "_run-{:02d}"
+    runTpl = "_run-{:1d}"
     caseSensitive = True
 
     # misc

--- a/docs/2-tutorial.md
+++ b/docs/2-tutorial.md
@@ -151,7 +151,7 @@ We could then update our configuration file.
 }
 ```
 
-For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](/docs/3-configuration/#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
+For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](3-configuration/#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
 
 ## Running dcm2bids
 

--- a/docs/2-tutorial.md
+++ b/docs/2-tutorial.md
@@ -151,7 +151,7 @@ We could then update our configuration file.
 }
 ```
 
-For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](3-configuration/#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
+For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](3-configuration.md#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
 
 ## Running dcm2bids
 

--- a/docs/3-configuration.md
+++ b/docs/3-configuration.md
@@ -84,11 +84,17 @@ For a longer example of a Dcm2Bids config json, see [here](https://github.com/un
 
 Optional field to change or add information in a sidecar.
 
+## key
+
+This is an optional field to organize descriptions by unique identifiers. On it's own, it will not have any effect on the bids output. However, adding these will allow you to refer to descriptions via their key in the `intendedFor` field. These must be unique across descriptions.
+
 ## intendedFor
 
 Optional field to add an `IntendedFor` entry in the sidecar of a fieldmap. Just put the index or a list of index of the description(s) that's intended for.
 
 Python index begins at `0` so in the example, `0` means it is intended for `task-rest_bold`.
+
+You may also refer to descriptions by their `key`. Just make sure that there exists a description with the `key` you refer to here.
 
 [^1]: For each acquisition, `dcm2niix` creates an associated `.json` file,
     containing information from the dicom header. These are known as

--- a/example/key_config.json
+++ b/example/key_config.json
@@ -1,0 +1,70 @@
+{
+    "searchMethod": "fnmatch",
+    "defaceTpl": "pydeface --outfile {dstFile} {srcFile}",
+    "descriptions": [
+        {
+            "dataType": "anat",
+            "modalityLabel": "T1w",
+            "criteria": {
+                "SeriesDescription": "*T1W_3D*"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "T2w",
+            "criteria": {
+                "SidecarFilename": "007*",
+                "EchoTime": 0.1
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "PD",
+            "criteria": {
+                "SeriesDescription": "*TSE*",
+                "EchoTime": 0.008
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "FLAIR",
+            "criteria": {
+                "SeriesDescription": "*FLAIR*"
+            }
+        },
+        {
+            "dataType": "dwi",
+            "modalityLabel": "dwi",
+            "criteria": {
+                "SeriesDescription": "*DWI*"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "SWI",
+            "criteria": {
+                "SeriesDescription": "*SWI*"
+            }
+        },
+        {
+            "key": "rsfMRI",
+            "dataType": "func",
+            "modalityLabel": "bold",
+            "customLabels": "task-rest",
+            "criteria": {
+                "SeriesDescription": "rs_fMRI"
+            },
+            "sidecarChanges": {
+                "SeriesDescription": "rsfMRI"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "fmap",
+            "criteria": {
+                "SidecarFilename": "*echo-4*"
+            },
+            "IntendedFor": "rsfMRI"
+        }
+    ]
+}

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         entry_points=ENTRY_POINTS,
         python_requires=">=3.6",
         use_scm_version=True,
-        setup_requires=['setuptools_scm'],
+        setup_requires=['setuptools'],
         install_requires=[
           'future>=0.17.1',
           # TODO: drop this when py3.6 is end-of-life

--- a/tests/data/config_test.json
+++ b/tests/data/config_test.json
@@ -28,6 +28,7 @@
             }
         },
         {
+            "key": "DTI",
             "dataType": "dwi",
             "modalityLabel": "dwi",
             "criteria": {
@@ -53,7 +54,7 @@
                 "EchoTime": 0.00738,
                 "ImageType": ["ORIGINAL", "PRIMARY", "M", "ND"]
             },
-            "IntendedFor": 3
+            "intendedFor": "DTI"
         },
         {
             "dataType": "dwi",

--- a/tests/test_dcm2bids.py
+++ b/tests/test_dcm2bids.py
@@ -61,7 +61,7 @@ def test_dcm2bids():
 
     data = load_json(
         os.path.join(
-            bidsDir.name, "sub-01", "localizer", "sub-01_run-01_localizer.json"
+            bidsDir.name, "sub-01", "localizer", "sub-01_run-1_localizer.json"
         )
     )
     assert data["ProcedureStepDescription"] == "Modify by dcm2bids"
@@ -112,7 +112,7 @@ def test_caseSensitive_false():
     path_localizer = os.path.join(bidsDir.name,
                                   "sub-01",
                                   "localizer",
-                                  "sub-01_run-01_localizer.json")
+                                  "sub-01_run-1_localizer.json")
 
     original_01_localizer = os.path.join(TEST_DATA_DIR,
                                          "sidecars",


### PR DESCRIPTION
This pull request is for the initial changes we want for our own dcm2bids usage. For each change, the relevant documentation and tests have been updated.

- You can now use keys instead of integer indices for use in the intendedFor field. See `docs/3-configuration.md` for more info, as well as the new example config file at `example/key_config.json`.
- Changed the run id parsing to remove unnecessary 0 to be more compliant with bids + fmriprep. For example, `run-01` becomes `run-1`. 
- Updated the `Dockerfile` and `setup.py` to be more like those in our other projects (tractify and dmri_analyses).

Feedback is greatly appreciated! We'll be able to add more features using this repo as well.